### PR TITLE
feat: 유저 회원가입 구현

### DIFF
--- a/src/main/java/com/kanvan/auth/controller/AuthController.java
+++ b/src/main/java/com/kanvan/auth/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.kanvan.auth.controller;
+
+import com.kanvan.auth.dto.UserSignupRequest;
+import com.kanvan.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(@Valid @RequestBody UserSignupRequest request) {
+
+        authService.signup(request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(null);
+    }
+}

--- a/src/main/java/com/kanvan/auth/dto/UserSignupRequest.java
+++ b/src/main/java/com/kanvan/auth/dto/UserSignupRequest.java
@@ -1,0 +1,21 @@
+package com.kanvan.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+public class UserSignupRequest {
+
+    @NotBlank(message = "계정은 필수입니다.")
+    @Length(min = 6, max = 20)
+    private String account;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Length(min = 8, max = 20)
+    private String password;
+
+    @NotBlank(message = "이름은 필수입니다.")
+    @Length(min = 2)
+    private String username;
+}

--- a/src/main/java/com/kanvan/auth/service/AuthService.java
+++ b/src/main/java/com/kanvan/auth/service/AuthService.java
@@ -1,6 +1,8 @@
 package com.kanvan.auth.service;
 
 import com.kanvan.auth.dto.UserSignupRequest;
+import com.kanvan.common.exception.CustomException;
+import com.kanvan.common.exception.ErrorCode;
 import com.kanvan.user.domain.User;
 import com.kanvan.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -18,7 +20,7 @@ public class AuthService {
     public void signup(UserSignupRequest request) {
 
         if (userRepository.findByAccount(request.getAccount()).isPresent()) {
-            throw new IllegalStateException(); //todo 예외처리 생성
+            throw new CustomException(ErrorCode.USER_ALREADY_EXIST);
         }
 
         User user = User.builder()

--- a/src/main/java/com/kanvan/auth/service/AuthService.java
+++ b/src/main/java/com/kanvan/auth/service/AuthService.java
@@ -17,7 +17,9 @@ public class AuthService {
     @Transactional
     public void signup(UserSignupRequest request) {
 
-        //todo 계정 중복 검사
+        if (userRepository.findByAccount(request.getAccount()).isPresent()) {
+            throw new IllegalStateException(); //todo 예외처리 생성
+        }
 
         User user = User.builder()
                 .account(request.getAccount())

--- a/src/main/java/com/kanvan/auth/service/AuthService.java
+++ b/src/main/java/com/kanvan/auth/service/AuthService.java
@@ -1,0 +1,30 @@
+package com.kanvan.auth.service;
+
+import com.kanvan.auth.dto.UserSignupRequest;
+import com.kanvan.user.domain.User;
+import com.kanvan.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+
+
+    @Transactional
+    public void signup(UserSignupRequest request) {
+
+        //todo 계정 중복 검사
+
+        User user = User.builder()
+                .account(request.getAccount())
+                .password(request.getPassword()) //todo 암호화
+                .username(request.getUsername())
+                .build();
+
+        userRepository.save(user);
+    }
+}

--- a/src/main/java/com/kanvan/common/exception/CustomException.java
+++ b/src/main/java/com/kanvan/common/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.kanvan.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/kanvan/common/exception/ErrorCode.java
+++ b/src/main/java/com/kanvan/common/exception/ErrorCode.java
@@ -1,0 +1,23 @@
+package com.kanvan.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    // 예시)
+    // RECRUITMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "R001", "해당하는 채용공고가 없습니다."),
+    USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "U001", "이미 계정이 존재합니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+}

--- a/src/main/java/com/kanvan/common/exception/ErrorResponse.java
+++ b/src/main/java/com/kanvan/common/exception/ErrorResponse.java
@@ -1,0 +1,48 @@
+package com.kanvan.common.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ErrorResponse {
+    private String errorCode;
+    private String errorMessage;
+
+    public static ErrorResponse of(String errorCode, String errorMessage) {
+        return ErrorResponse.builder()
+                .errorCode(errorCode)
+                .errorMessage(errorMessage)
+                .build();
+    }
+
+    public static ErrorResponse of(String errorCode, BindingResult bindingResult) {
+        return ErrorResponse.builder()
+                .errorCode(errorCode)
+                .errorMessage(createErrorMessage(bindingResult))
+                .build();
+    }
+
+    private static String createErrorMessage(BindingResult bindingResult) {
+        StringBuilder sb = new StringBuilder();
+        boolean isFirst = true;
+        List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+        for(FieldError fieldError : fieldErrors) {
+            if(!isFirst) {
+                sb.append(", ");
+            } else {
+                isFirst = false;
+            }
+            sb.append("[");
+            sb.append(fieldError.getField());
+            sb.append("] ");
+            sb.append(fieldError.getDefaultMessage());
+        }
+        return sb.toString();
+    }
+}
+

--- a/src/main/java/com/kanvan/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kanvan/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.kanvan.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // javax.validation.Valid binding error 가 발생하는 경우
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+        log.error("handleBindException, {}", e.getMessage());
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST.toString(), e.getBindingResult());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    // @RequestParam 이 enum 으로 binding 되지 못한 경우
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.error("handleMethodArgumentTypeMismatchException, {}", e.getMessage());
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST.toString(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    // 지원하지 않는 HTTP method 를 호출하는 경우
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error("handleHttpRequestMethodNotSupportedException, {}", e.getMessage());
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.METHOD_NOT_ALLOWED.toString(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(errorResponse);
+    }
+
+    // 비즈니스 로직 실행 도중 예외 발생하는 경우
+    @ExceptionHandler(value = CustomException.class)
+    protected ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        log.error("CustomException, {}", e.getMessage());
+        ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage());
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(errorResponse);
+    }
+
+    // 그 외 예외가 발생하는 경우
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Exception, {}", e.getMessage());
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.toString(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+}

--- a/src/main/java/com/kanvan/user/domain/User.java
+++ b/src/main/java/com/kanvan/user/domain/User.java
@@ -4,12 +4,29 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String account;
 
+    private String password;
+
+    private String username;
+
+    @Builder
+    public User(String account, String password, String username) {
+        this.account = account;
+        this.password = password;
+        this.username = username;
+    }
 }

--- a/src/main/java/com/kanvan/user/repository/UserRepository.java
+++ b/src/main/java/com/kanvan/user/repository/UserRepository.java
@@ -3,5 +3,9 @@ package com.kanvan.user.repository;
 import com.kanvan.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByAccount(String account);
 }

--- a/src/main/java/com/kanvan/user/repository/UserRepository.java
+++ b/src/main/java/com/kanvan/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.kanvan.user.repository;
+
+import com.kanvan.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

유저 회원가입 api 구현하였습니다.
요청 데이터 validation 추가 및 중복 계정 검사
비밀번호 암호화는 security 설정 후 passwordencoder로 진행 예정

## 📋 변경 사항

- [x] 새로운 기능 추가

## 📸 스크린샷

<img width="600" alt="스크린샷 2023-11-28 오후 4 12 05" src="https://github.com/cjw9506/kanvan/assets/63503519/78414d4a-8daa-45d4-8365-584abff2575e">

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.

## 📎 관련 이슈

#1 
