### PR TITLE
feat: 컬럼 기능 구현

### DIFF
--- a/src/main/java/com/kanvan/column/controller/ColumnController.java
+++ b/src/main/java/com/kanvan/column/controller/ColumnController.java
@@ -1,16 +1,16 @@
 package com.kanvan.column.controller;
 
 import com.kanvan.column.dto.ColumnCreateRequest;
+import com.kanvan.column.dto.ColumnsResponse;
 import com.kanvan.column.service.ColumnService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/columns")
@@ -26,6 +26,15 @@ public class ColumnController {
         columnService.create(request, authentication);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(null);
+    }
+
+    @GetMapping("/{teamId}")
+    public ResponseEntity<?> getColumns(@PathVariable(name = "teamId") Long teamId,
+                                        Authentication authentication) {
+
+        List<ColumnsResponse> response = columnService.getColumns(teamId, authentication);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
 

--- a/src/main/java/com/kanvan/column/controller/ColumnController.java
+++ b/src/main/java/com/kanvan/column/controller/ColumnController.java
@@ -1,6 +1,7 @@
 package com.kanvan.column.controller;
 
 import com.kanvan.column.dto.ColumnCreateRequest;
+import com.kanvan.column.dto.ColumnDeleteRequest;
 import com.kanvan.column.dto.ColumnUpdateRequest;
 import com.kanvan.column.dto.ColumnsResponse;
 import com.kanvan.column.service.ColumnService;
@@ -39,7 +40,7 @@ public class ColumnController {
     }
 
     @PatchMapping
-    public ResponseEntity<?> updateColumnOrder(@RequestBody ColumnUpdateRequest request,
+    public ResponseEntity<?> updateColumnOrder(@Valid @RequestBody ColumnUpdateRequest request,
                                                Authentication authentication) {
         columnService.updateColumnOrder(request, authentication);
 

--- a/src/main/java/com/kanvan/column/controller/ColumnController.java
+++ b/src/main/java/com/kanvan/column/controller/ColumnController.java
@@ -1,0 +1,28 @@
+package com.kanvan.column.controller;
+
+import com.kanvan.column.dto.ColumnCreateRequest;
+import com.kanvan.column.service.ColumnService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/columns")
+@RequiredArgsConstructor
+public class ColumnController {
+
+    private final ColumnService columnService;
+
+    public ResponseEntity<?> create(@Valid @RequestBody ColumnCreateRequest request,
+                                    Authentication authentication) {
+
+        columnService.create(request, authentication);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(null);
+    }
+}

--- a/src/main/java/com/kanvan/column/controller/ColumnController.java
+++ b/src/main/java/com/kanvan/column/controller/ColumnController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,6 +19,7 @@ public class ColumnController {
 
     private final ColumnService columnService;
 
+    @PostMapping
     public ResponseEntity<?> create(@Valid @RequestBody ColumnCreateRequest request,
                                     Authentication authentication) {
 
@@ -25,4 +27,6 @@ public class ColumnController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(null);
     }
+
+
 }

--- a/src/main/java/com/kanvan/column/controller/ColumnController.java
+++ b/src/main/java/com/kanvan/column/controller/ColumnController.java
@@ -19,6 +19,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ColumnController {
 
+    //todo 컬럼 api restful하게 바꾸기
+
     private final ColumnService columnService;
 
     @PostMapping

--- a/src/main/java/com/kanvan/column/controller/ColumnController.java
+++ b/src/main/java/com/kanvan/column/controller/ColumnController.java
@@ -1,6 +1,7 @@
 package com.kanvan.column.controller;
 
 import com.kanvan.column.dto.ColumnCreateRequest;
+import com.kanvan.column.dto.ColumnUpdateRequest;
 import com.kanvan.column.dto.ColumnsResponse;
 import com.kanvan.column.service.ColumnService;
 import jakarta.validation.Valid;
@@ -37,5 +38,11 @@ public class ColumnController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+    @PatchMapping
+    public ResponseEntity<?> updateColumnOrder(@RequestBody ColumnUpdateRequest request,
+                                               Authentication authentication) {
+        columnService.updateColumnOrder(request, authentication);
 
+        return ResponseEntity.status(HttpStatus.OK).body(null);
+    }
 }

--- a/src/main/java/com/kanvan/column/controller/ColumnController.java
+++ b/src/main/java/com/kanvan/column/controller/ColumnController.java
@@ -46,4 +46,15 @@ public class ColumnController {
 
         return ResponseEntity.status(HttpStatus.OK).body(null);
     }
+
+    @DeleteMapping("/{columnId}")
+    public ResponseEntity<?> deleteColumn(@PathVariable(name = "columnId") Long columnId,
+                                          @RequestBody ColumnDeleteRequest request,
+                                          Authentication authentication) {
+
+        columnService.deleteColumn(columnId, request, authentication);
+
+        return ResponseEntity.status(HttpStatus.OK).body(null);
+
+    }
 }

--- a/src/main/java/com/kanvan/column/domain/Column.java
+++ b/src/main/java/com/kanvan/column/domain/Column.java
@@ -1,0 +1,31 @@
+package com.kanvan.column.domain;
+
+import com.kanvan.team.domain.Team;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Column {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    //순서
+    private String order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Team team;
+
+    @Builder
+    public Column(String name, String order, Team team) {
+        this.name = name;
+        this.order = order;
+        this.team = team;
+    }
+}

--- a/src/main/java/com/kanvan/column/domain/Columns.java
+++ b/src/main/java/com/kanvan/column/domain/Columns.java
@@ -26,8 +26,7 @@ public class Columns {
     @Builder
     public Columns(String name, int columnOrder, Team team) {
         this.name = name;
-        this.columnOrder = columnOrder
-        ;
+        this.columnOrder = columnOrder;
         this.team = team;
     }
 }

--- a/src/main/java/com/kanvan/column/domain/Columns.java
+++ b/src/main/java/com/kanvan/column/domain/Columns.java
@@ -29,4 +29,8 @@ public class Columns {
         this.columnOrder = columnOrder;
         this.team = team;
     }
+
+    public void updateColumnOrder(int columnOrder) {
+        this.columnOrder = columnOrder;
+    }
 }

--- a/src/main/java/com/kanvan/column/domain/Columns.java
+++ b/src/main/java/com/kanvan/column/domain/Columns.java
@@ -3,8 +3,12 @@ package com.kanvan.column.domain;
 import com.kanvan.team.domain.Team;
 import jakarta.persistence.*;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor
 public class Columns {
 
     @Id
@@ -14,15 +18,16 @@ public class Columns {
     private String name;
 
     //순서
-    private int order;
+    private int columnOrder;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Team team;
 
     @Builder
-    public Columns(String name, int order, Team team) {
+    public Columns(String name, int columnOrder, Team team) {
         this.name = name;
-        this.order = order;
+        this.columnOrder = columnOrder
+        ;
         this.team = team;
     }
 }

--- a/src/main/java/com/kanvan/column/domain/Columns.java
+++ b/src/main/java/com/kanvan/column/domain/Columns.java
@@ -3,27 +3,24 @@ package com.kanvan.column.domain;
 import com.kanvan.team.domain.Team;
 import jakarta.persistence.*;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
-@Getter
-@NoArgsConstructor
-public class Column {
+public class Columns {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
 
     //순서
-    private String order;
+    private int order;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Team team;
 
     @Builder
-    public Column(String name, String order, Team team) {
+    public Columns(String name, int order, Team team) {
         this.name = name;
         this.order = order;
         this.team = team;

--- a/src/main/java/com/kanvan/column/dto/ColumnCreateRequest.java
+++ b/src/main/java/com/kanvan/column/dto/ColumnCreateRequest.java
@@ -1,0 +1,10 @@
+package com.kanvan.column.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ColumnCreateRequest {
+
+    private Long teamId;
+    private String name;
+}

--- a/src/main/java/com/kanvan/column/dto/ColumnDeleteRequest.java
+++ b/src/main/java/com/kanvan/column/dto/ColumnDeleteRequest.java
@@ -1,0 +1,11 @@
+package com.kanvan.column.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ColumnDeleteRequest {
+
+    @NotNull(message = "팀 id는 필수입니다.")
+    private Long teamId;
+}

--- a/src/main/java/com/kanvan/column/dto/ColumnUpdateRequest.java
+++ b/src/main/java/com/kanvan/column/dto/ColumnUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.kanvan.column.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ColumnUpdateRequest {
+
+    @NotNull(message = "팀 id는 필수입니다.")
+    private Long teamId;
+
+    private int currentColumnOrder;
+    private int futureColumnOrder;
+}

--- a/src/main/java/com/kanvan/column/dto/ColumnsResponse.java
+++ b/src/main/java/com/kanvan/column/dto/ColumnsResponse.java
@@ -1,0 +1,22 @@
+package com.kanvan.column.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+public class ColumnsResponse {
+
+    private Long columnId;
+    private String name;
+    private int columnOrder;
+
+    @Builder
+    public ColumnsResponse(Long columnId, String name, int columnOrder) {
+        this.columnId = columnId;
+        this.name = name;
+        this.columnOrder = columnOrder;
+    }
+}

--- a/src/main/java/com/kanvan/column/repository/ColumnRepository.java
+++ b/src/main/java/com/kanvan/column/repository/ColumnRepository.java
@@ -11,4 +11,6 @@ public interface ColumnRepository extends JpaRepository<Columns, Long> {
     List<Columns> findByTeam(Team team);
 
     List<Columns> findByTeamOrderByColumnOrder(Team team);
+
+    List<Columns> findByColumnOrderBetween(int min, int max);
 }

--- a/src/main/java/com/kanvan/column/repository/ColumnRepository.java
+++ b/src/main/java/com/kanvan/column/repository/ColumnRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface ColumnRepository extends JpaRepository<Columns, Long> {
 
     List<Columns> findByTeam(Team team);
+
+    List<Columns> findByTeamOrderByColumnOrder(Team team);
 }

--- a/src/main/java/com/kanvan/column/repository/ColumnRepository.java
+++ b/src/main/java/com/kanvan/column/repository/ColumnRepository.java
@@ -13,4 +13,6 @@ public interface ColumnRepository extends JpaRepository<Columns, Long> {
     List<Columns> findByTeamOrderByColumnOrder(Team team);
 
     List<Columns> findByColumnOrderBetween(int min, int max);
+
+    List<Columns> findByColumnOrderGreaterThan(int columnOrder);
 }

--- a/src/main/java/com/kanvan/column/repository/ColumnRepository.java
+++ b/src/main/java/com/kanvan/column/repository/ColumnRepository.java
@@ -1,0 +1,12 @@
+package com.kanvan.column.repository;
+
+import com.kanvan.column.domain.Columns;
+import com.kanvan.team.domain.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ColumnRepository extends JpaRepository<Columns, Long> {
+
+    List<Columns> findByTeam(Team team);
+}

--- a/src/main/java/com/kanvan/column/service/ColumnService.java
+++ b/src/main/java/com/kanvan/column/service/ColumnService.java
@@ -1,0 +1,54 @@
+package com.kanvan.column.service;
+
+import com.kanvan.column.domain.Columns;
+import com.kanvan.column.dto.ColumnCreateRequest;
+import com.kanvan.column.repository.ColumnRepository;
+import com.kanvan.common.exception.CustomException;
+import com.kanvan.common.exception.ErrorCode;
+import com.kanvan.team.domain.Member;
+import com.kanvan.team.domain.Team;
+import com.kanvan.team.domain.TeamRole;
+import com.kanvan.team.repository.MemberRepository;
+import com.kanvan.team.repository.TeamRepository;
+import com.kanvan.user.domain.User;
+import com.kanvan.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ColumnService {
+
+    private final ColumnRepository columnRepository;
+    private final UserRepository userRepository;
+    private final TeamRepository teamRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void create(ColumnCreateRequest request, Authentication authentication) {
+
+        User user = userRepository.findByAccount(authentication.getName()).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Team team = teamRepository.findById(request.getTeamId()).orElseThrow(
+                () -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
+
+        Member member = memberRepository.findByMemberAndTeam(user, team).orElseThrow(
+                () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (member.getRole().equals(TeamRole.LEADER)) throw new CustomException(ErrorCode.MEMBER_NOT_LEADER);
+
+        int order = columnRepository.findByTeam(team).size() + 1;
+
+        Columns column = Columns.builder()
+                .name(request.getName())
+                .columnOrder(order)
+                .team(team)
+                .build();
+
+        columnRepository.save(column);
+
+    }
+}

--- a/src/main/java/com/kanvan/column/service/ColumnService.java
+++ b/src/main/java/com/kanvan/column/service/ColumnService.java
@@ -38,7 +38,8 @@ public class ColumnService {
         Member member = memberRepository.findByMemberAndTeam(user, team).orElseThrow(
                 () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
-        if (member.getRole().equals(TeamRole.LEADER)) throw new CustomException(ErrorCode.MEMBER_NOT_LEADER);
+        System.out.println(member.getRole());
+        if (member.getRole() != TeamRole.LEADER) throw new CustomException(ErrorCode.MEMBER_NOT_LEADER);
 
         int order = columnRepository.findByTeam(team).size() + 1;
 

--- a/src/main/java/com/kanvan/common/exception/ErrorCode.java
+++ b/src/main/java/com/kanvan/common/exception/ErrorCode.java
@@ -20,6 +20,9 @@ public enum ErrorCode {
     //member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "해당 멤버는 존재하지 않습니다."),
     MEMBER_NOT_LEADER(HttpStatus.BAD_REQUEST, "M002", "해당 멤버는 리더가 아닙니다."),
+
+    //column
+    COLUMN_NOT_FOUND(HttpStatus.NOT_FOUND, "C001", "해당 컬럼은 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/kanvan/common/exception/ErrorCode.java
+++ b/src/main/java/com/kanvan/common/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
 
     //member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "해당 멤버는 존재하지 않습니다."),
+    MEMBER_NOT_LEADER(HttpStatus.BAD_REQUEST, "M002", "해당 멤버는 리더가 아닙니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

- 컬럼 생성(이름, 순서) → 추가된 `column` 은 항시 맨 마지막에 위치 (`팀장 권한`)
- 전체 조회(팀, 컬럼들,티켓 목록) → 컬럼 순서에 맞게 반환(`팀장 및 팀원 권한`)
- 컬럼 수정(이름 변경) → (`팀장 및 팀원 권한`)
- 컬럼 삭제(티켓이 없는 경우에만) → (`팀장 권한`)

## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)

## 📸 스크린샷

(선택 사항: 변경된 내용을 시각적으로 보여주기 위해 스크린샷을 첨부하세요.)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#12 

## 🙌 리뷰 및 피드백

(리뷰어들께 질문하거나 특정 리뷰를 요청하는 내용을 작성하세요.)
