### PR TITLE
feat: 티켓 관련 기능 구현

### DIFF
--- a/src/main/java/com/kanvan/column/repository/ColumnRepository.java
+++ b/src/main/java/com/kanvan/column/repository/ColumnRepository.java
@@ -5,6 +5,7 @@ import com.kanvan.team.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ColumnRepository extends JpaRepository<Columns, Long> {
 
@@ -15,4 +16,6 @@ public interface ColumnRepository extends JpaRepository<Columns, Long> {
     List<Columns> findByColumnOrderBetween(int min, int max);
 
     List<Columns> findByColumnOrderGreaterThan(int columnOrder);
+
+    Optional<Columns> findColumnsByIdAndTeamId(Long columnId, Long teamId);
 }

--- a/src/main/java/com/kanvan/column/repository/ColumnRepository.java
+++ b/src/main/java/com/kanvan/column/repository/ColumnRepository.java
@@ -18,4 +18,7 @@ public interface ColumnRepository extends JpaRepository<Columns, Long> {
     List<Columns> findByColumnOrderGreaterThan(int columnOrder);
 
     Optional<Columns> findColumnsByIdAndTeamId(Long columnId, Long teamId);
+
+    Optional<Columns> findByTeamAndColumnOrder(Team team, int columnOrder);
+
 }

--- a/src/main/java/com/kanvan/common/exception/ErrorCode.java
+++ b/src/main/java/com/kanvan/common/exception/ErrorCode.java
@@ -23,6 +23,9 @@ public enum ErrorCode {
 
     //column
     COLUMN_NOT_FOUND(HttpStatus.NOT_FOUND, "C001", "해당 컬럼은 존재하지 않습니다."),
+
+    //ticket
+    TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "T001", "해당 티켓은 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/kanvan/team/repository/MemberRepository.java
+++ b/src/main/java/com/kanvan/team/repository/MemberRepository.java
@@ -17,4 +17,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findByTeam(Team team);
 
     List<Member> findByMemberAndInviteStatus(User user, Invite status);
+
+    Optional<Member> findByMemberAndTeamId(User user, Long teamId);
 }

--- a/src/main/java/com/kanvan/ticket/controller/TicketController.java
+++ b/src/main/java/com/kanvan/ticket/controller/TicketController.java
@@ -1,6 +1,7 @@
 package com.kanvan.ticket.controller;
 
 import com.kanvan.ticket.dto.TicketCreateRequest;
+import com.kanvan.ticket.dto.TicketOrderUpdateRequest;
 import com.kanvan.ticket.dto.TicketUpdateRequest;
 import com.kanvan.ticket.service.TicketService;
 import jakarta.validation.Valid;
@@ -29,7 +30,7 @@ public class TicketController {
     }
 
     @PatchMapping("/teams/{teamId}/columns/{columnId}/tickets/{ticketId}")
-    public ResponseEntity<?> update(@PathVariable(name = "teamId") Long teamId,
+    public ResponseEntity<?> updateFields(@PathVariable(name = "teamId") Long teamId,
                                     @PathVariable(name = "columnId") Long columnId,
                                     @PathVariable(name = "ticketId") Long ticketId,
                                     @Valid @RequestBody TicketUpdateRequest request,
@@ -39,4 +40,17 @@ public class TicketController {
 
         return ResponseEntity.status(HttpStatus.OK).body(null);
     }
+
+    @PatchMapping("/{teamName}/columns/{columnId}/tickets/{ticketId}/order")
+    public ResponseEntity<?> updateOrders(@PathVariable(name = "teamName") String teamName,
+                                          @PathVariable(name = "columnId") int columnId,
+                                          @PathVariable(name = "ticketId") int ticketId,
+                                          @Valid @RequestBody TicketOrderUpdateRequest request,
+                                          Authentication authentication) {
+
+        ticketService.updateOrders(teamName, columnId, ticketId, request, authentication);
+
+        return ResponseEntity.status(HttpStatus.OK).body(null);
+    }
+
 }

--- a/src/main/java/com/kanvan/ticket/controller/TicketController.java
+++ b/src/main/java/com/kanvan/ticket/controller/TicketController.java
@@ -53,4 +53,14 @@ public class TicketController {
         return ResponseEntity.status(HttpStatus.OK).body(null);
     }
 
+    @DeleteMapping("/{teamName}/columns/{columnId}/tickets/{ticketId}")
+    public ResponseEntity<?> delete(@PathVariable(name = "teamName") String teamName,
+                                    @PathVariable(name = "columnId") int columnId,
+                                    @PathVariable(name = "ticketId") int ticketId,
+                                    Authentication authentication) {
+        ticketService.delete(teamName, columnId, ticketId, authentication);
+
+        return ResponseEntity.status(HttpStatus.OK).body(null);
+    }
+
 }

--- a/src/main/java/com/kanvan/ticket/controller/TicketController.java
+++ b/src/main/java/com/kanvan/ticket/controller/TicketController.java
@@ -1,0 +1,29 @@
+package com.kanvan.ticket.controller;
+
+import com.kanvan.ticket.dto.TicketCreateRequest;
+import com.kanvan.ticket.service.TicketService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class TicketController {
+
+    private final TicketService ticketService;
+
+    @PostMapping("/teams/{teamId}/columns/{columnId}/tickets")
+    public ResponseEntity<?> create(@PathVariable(name = "teamId") Long teamId,
+                                    @PathVariable(name = "columnId") Long columnId,
+                                    @Valid @RequestBody TicketCreateRequest request,
+                                    Authentication authentication) {
+
+        ticketService.create(teamId, columnId, request, authentication);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(null);
+    }
+}

--- a/src/main/java/com/kanvan/ticket/controller/TicketController.java
+++ b/src/main/java/com/kanvan/ticket/controller/TicketController.java
@@ -1,6 +1,7 @@
 package com.kanvan.ticket.controller;
 
 import com.kanvan.ticket.dto.TicketCreateRequest;
+import com.kanvan.ticket.dto.TicketUpdateRequest;
 import com.kanvan.ticket.service.TicketService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,5 +26,17 @@ public class TicketController {
         ticketService.create(teamId, columnId, request, authentication);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(null);
+    }
+
+    @PatchMapping("/teams/{teamId}/columns/{columnId}/tickets/{ticketId}")
+    public ResponseEntity<?> update(@PathVariable(name = "teamId") Long teamId,
+                                    @PathVariable(name = "columnId") Long columnId,
+                                    @PathVariable(name = "ticketId") Long ticketId,
+                                    @Valid @RequestBody TicketUpdateRequest request,
+                                    Authentication authentication) {
+
+        ticketService.update(teamId, columnId, ticketId, request, authentication);
+
+        return ResponseEntity.status(HttpStatus.OK).body(null);
     }
 }

--- a/src/main/java/com/kanvan/ticket/domain/Tag.java
+++ b/src/main/java/com/kanvan/ticket/domain/Tag.java
@@ -1,0 +1,6 @@
+package com.kanvan.ticket.domain;
+
+public enum Tag {
+
+    BACKEND, FRONTEND, DESIGN, QA, PM, DOCUMENT
+}

--- a/src/main/java/com/kanvan/ticket/domain/Ticket.java
+++ b/src/main/java/com/kanvan/ticket/domain/Ticket.java
@@ -45,4 +45,12 @@ public class Ticket {
         this.manager = manager;
         this.column = column;
     }
+
+    public void update(String title, Tag tag, String workingTime, String deadline, User manager) {
+        this.title = title != null ? title : this.title;
+        this.tag = tag != null ? tag : this.tag;
+        this.workingTime = workingTime != null ? workingTime : this.workingTime;
+        this.deadline = deadline != null ? deadline : this.deadline;
+        this.manager = manager != null ? manager : this.manager;
+    }
 }

--- a/src/main/java/com/kanvan/ticket/domain/Ticket.java
+++ b/src/main/java/com/kanvan/ticket/domain/Ticket.java
@@ -53,4 +53,12 @@ public class Ticket {
         this.deadline = deadline != null ? deadline : this.deadline;
         this.manager = manager != null ? manager : this.manager;
     }
+
+    public void updateTicketOrder(int ticketOrder) {
+        this.ticketOrder = ticketOrder;
+    }
+
+    public void updateColumn(Columns column) {
+        this.column = column != null ? column : this.column;
+    }
 }

--- a/src/main/java/com/kanvan/ticket/domain/Ticket.java
+++ b/src/main/java/com/kanvan/ticket/domain/Ticket.java
@@ -1,0 +1,48 @@
+package com.kanvan.ticket.domain;
+
+import com.kanvan.column.domain.Columns;
+import com.kanvan.user.domain.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Ticket {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int ticketOrder;
+
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    private Tag tag;
+
+    private String workingTime;
+
+    private String deadline;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User manager;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "column_id")
+    private Columns column;
+
+    @Builder
+    public Ticket(int ticketOrder, String title, Tag tag, String workingTime,
+                  String deadline, User manager, Columns column) {
+        this.ticketOrder = ticketOrder;
+        this.title = title;
+        this.tag = tag;
+        this.workingTime = workingTime;
+        this.deadline = deadline;
+        this.manager = manager;
+        this.column = column;
+    }
+}

--- a/src/main/java/com/kanvan/ticket/dto/TicketCreateRequest.java
+++ b/src/main/java/com/kanvan/ticket/dto/TicketCreateRequest.java
@@ -1,0 +1,24 @@
+package com.kanvan.ticket.dto;
+
+import com.kanvan.ticket.domain.Tag;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class TicketCreateRequest {
+
+    @NotBlank(message = "제목은 필수입니다.")
+    private String title;
+
+    @NotNull(message = "작업태그는 필수입니다.")
+    private Tag tag;
+
+    private String workingTime;
+
+    private String deadline;
+
+    private String memberAccount;
+
+
+}

--- a/src/main/java/com/kanvan/ticket/dto/TicketOrderUpdateRequest.java
+++ b/src/main/java/com/kanvan/ticket/dto/TicketOrderUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.kanvan.ticket.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TicketOrderUpdateRequest {
+
+    private int columnId;
+
+    private int ticketOrder;
+}

--- a/src/main/java/com/kanvan/ticket/dto/TicketUpdateRequest.java
+++ b/src/main/java/com/kanvan/ticket/dto/TicketUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.kanvan.ticket.dto;
+
+import com.kanvan.ticket.domain.Tag;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class TicketUpdateRequest {
+
+    private String title;
+
+    private Tag tag;
+
+    private String workingTime;
+
+    private String deadline;
+
+    @NotBlank(message = "계정은 필수입니다.")
+    private String memberAccount;
+}

--- a/src/main/java/com/kanvan/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/kanvan/ticket/repository/TicketRepository.java
@@ -1,0 +1,12 @@
+package com.kanvan.ticket.repository;
+
+import com.kanvan.column.domain.Columns;
+import com.kanvan.ticket.domain.Ticket;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TicketRepository extends JpaRepository<Ticket, Long> {
+
+    List<Ticket> findByColumn(Columns column);
+}

--- a/src/main/java/com/kanvan/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/kanvan/ticket/repository/TicketRepository.java
@@ -5,8 +5,15 @@ import com.kanvan.ticket.domain.Ticket;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
     List<Ticket> findByColumn(Columns column);
+
+    Optional<Ticket> findByTicketOrder(int ticketOrder);
+
+    List<Ticket> findByTicketOrderBetween(int min, int max);
+
+    List<Ticket> findByColumnAndTicketOrderGreaterThan(Columns column, int ticketOrder);
 }

--- a/src/main/java/com/kanvan/ticket/service/TicketService.java
+++ b/src/main/java/com/kanvan/ticket/service/TicketService.java
@@ -155,16 +155,33 @@ public class TicketService {
                 }
             });
         }
+    }
 
+    @Transactional
+    public void delete(String teamName, int columnId, int ticketId, Authentication authentication) {
+        Ticket ticket = ticketRepository.findByTicketOrder(ticketId).orElseThrow(
+                () -> new CustomException(ErrorCode.TICKET_NOT_FOUND));
 
+        Team team = teamRepository.findByTeamName(teamName).orElseThrow(
+                () -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
 
+        Columns column = columnRepository.findByTeamAndColumnOrder(team, columnId).orElseThrow(
+                () -> new CustomException(ErrorCode.COLUMN_NOT_FOUND));
 
+        //===== 권한 확인 =====//
+        User user = userRepository.findByAccount(authentication.getName()).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
+        Member member = memberRepository.findByMemberAndTeam(user, team).orElseThrow(
+                () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        //===== 권한 확인 =====//
 
+        ticketRepository.delete(ticket);
 
+        List<Ticket> tickets = ticketRepository.findByColumnAndTicketOrderGreaterThan(column, ticketId);
 
-
-//        ticket.updateOrders(request.getTicketOrder(), request.getColumnId());
-
+        tickets.forEach(tk -> {
+            tk.updateTicketOrder(tk.getTicketOrder() - 1);
+                });
     }
 }

--- a/src/main/java/com/kanvan/ticket/service/TicketService.java
+++ b/src/main/java/com/kanvan/ticket/service/TicketService.java
@@ -10,6 +10,7 @@ import com.kanvan.team.repository.MemberRepository;
 import com.kanvan.team.repository.TeamRepository;
 import com.kanvan.ticket.domain.Ticket;
 import com.kanvan.ticket.dto.TicketCreateRequest;
+import com.kanvan.ticket.dto.TicketUpdateRequest;
 import com.kanvan.ticket.repository.TicketRepository;
 import com.kanvan.user.domain.User;
 import com.kanvan.user.repository.UserRepository;
@@ -27,12 +28,14 @@ public class TicketService {
     private final TicketRepository ticketRepository;
     private final ColumnRepository columnRepository;
     private final UserRepository userRepository;
-    private final TeamRepository teamRepository;
     private final MemberRepository memberRepository;
 
     @Transactional
     public void create(Long teamId, Long columnId, TicketCreateRequest request,
                        Authentication authentication) {
+
+        // /지원팀/columns/1/ticket
+        // 팀이름/columns/column순서/tickets/티켓순서
 
         //todo 조회 줄이기 -> if i can
 
@@ -69,5 +72,28 @@ public class TicketService {
 
         ticketRepository.save(ticket);
 
+    }
+
+    @Transactional
+    public void update(Long teamId, Long columnId, Long ticketId,
+                       TicketUpdateRequest request, Authentication authentication) {
+
+        Ticket ticket = ticketRepository.findById(ticketId).orElseThrow(
+                () -> new CustomException(ErrorCode.TICKET_NOT_FOUND));
+
+        Columns column = columnRepository.findColumnsByIdAndTeamId(teamId, columnId).orElseThrow(
+                () -> new CustomException(ErrorCode.COLUMN_NOT_FOUND));
+
+        User user = userRepository.findByAccount(authentication.getName()).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Member member = memberRepository.findByMemberAndTeamId(user, teamId).orElseThrow(
+                () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        User changedUser = userRepository.findByAccount(request.getMemberAccount()).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        ticket.update(request.getTitle(), request.getTag(), request.getWorkingTime(),
+                request.getDeadline(), changedUser);
     }
 }

--- a/src/main/java/com/kanvan/ticket/service/TicketService.java
+++ b/src/main/java/com/kanvan/ticket/service/TicketService.java
@@ -1,0 +1,73 @@
+package com.kanvan.ticket.service;
+
+import com.kanvan.column.domain.Columns;
+import com.kanvan.column.repository.ColumnRepository;
+import com.kanvan.common.exception.CustomException;
+import com.kanvan.common.exception.ErrorCode;
+import com.kanvan.team.domain.Member;
+import com.kanvan.team.domain.Team;
+import com.kanvan.team.repository.MemberRepository;
+import com.kanvan.team.repository.TeamRepository;
+import com.kanvan.ticket.domain.Ticket;
+import com.kanvan.ticket.dto.TicketCreateRequest;
+import com.kanvan.ticket.repository.TicketRepository;
+import com.kanvan.user.domain.User;
+import com.kanvan.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Service
+@RequiredArgsConstructor
+@RequestMapping("/api/tickets")
+public class TicketService {
+
+    private final TicketRepository ticketRepository;
+    private final ColumnRepository columnRepository;
+    private final UserRepository userRepository;
+    private final TeamRepository teamRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void create(Long teamId, Long columnId, TicketCreateRequest request,
+                       Authentication authentication) {
+
+        //todo 조회 줄이기 -> if i can
+
+        //작업자
+        User manager = userRepository.findByAccount(request.getMemberAccount()).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        //컬럼
+        Columns column = columnRepository.findColumnsByIdAndTeamId(teamId, columnId).orElseThrow(
+                () -> new CustomException(ErrorCode.COLUMN_NOT_FOUND));
+
+        //===== 여기부터는 권한때문인데 고민해봐야함 =====//
+        User user = userRepository.findByAccount(authentication.getName()).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Member member = memberRepository.findByMemberAndTeamId(user, teamId).orElseThrow(
+                () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        Member worker = memberRepository.findByMemberAndTeamId(manager, teamId).orElseThrow(
+                () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        //===== 여기까지는 권한때문인데 고민해봐야함 =====//
+
+        int order =  ticketRepository.findByColumn(column).size();
+
+        Ticket ticket = Ticket.builder()
+                .ticketOrder(order + 1)
+                .title(request.getTitle())
+                .tag(request.getTag())
+                .workingTime(request.getWorkingTime())
+                .deadline(request.getDeadline())
+                .manager(manager)
+                .column(column)
+                .build();
+
+        ticketRepository.save(ticket);
+
+    }
+}


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

- 티켓(`해당 팀원 및 팀장 권한`)
    - `특정 컬럼 하위`에 티켓 생성 → 필드 : 순위, 타이틀, 태그, 작업분량, 작업기한, 담당자 등
    - 티켓 수정(모든 필드 순서 제외) → (`팀장 및 팀원 권한`)
    - 티켓 수정(순서) → (`팀장 및 팀원 권한`) 
    - 티켓 삭제 → (`팀장 및 팀원 권한`)

## 📋 변경 사항

- [x] 새로운 기능 추가

## 📸 스크린샷

(선택 사항: 변경된 내용을 시각적으로 보여주기 위해 스크린샷을 첨부하세요.)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#14 

## 🙌 리뷰 및 피드백

(리뷰어들께 질문하거나 특정 리뷰를 요청하는 내용을 작성하세요.)
