### PR TITLE
feat: 팀 생성 및 초대 수락 시 권한 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.0'
+	id 'org.springframework.boot' version '3.1.6'
 	id 'io.spring.dependency-management' version '1.1.4'
 }
 
@@ -43,3 +43,5 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+

--- a/src/main/java/com/kanvan/auth/config/SecurityConfig.java
+++ b/src/main/java/com/kanvan/auth/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
@@ -17,6 +18,7 @@ import static org.springframework.http.HttpMethod.POST;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/src/main/java/com/kanvan/team/service/TeamService.java
+++ b/src/main/java/com/kanvan/team/service/TeamService.java
@@ -54,9 +54,7 @@ public class TeamService {
 
         memberRepository.save(teamMember);
 
-        int teamId = Long.valueOf(team.getId()).intValue();
-
-        String authority = teamId + "_" + "LEADER";
+        String authority = team.getId() + "_LEADER";
 
         user.setTeamAuthority(authority);
     }

--- a/src/main/java/com/kanvan/team/service/TeamService.java
+++ b/src/main/java/com/kanvan/team/service/TeamService.java
@@ -53,6 +53,12 @@ public class TeamService {
                 .build();
 
         memberRepository.save(teamMember);
+
+        int teamId = Long.valueOf(team.getId()).intValue();
+
+        String authority = teamId + "_" + "LEADER";
+
+        user.setTeamAuthority(authority);
     }
 
     @Transactional

--- a/src/main/java/com/kanvan/team/service/TeamService.java
+++ b/src/main/java/com/kanvan/team/service/TeamService.java
@@ -111,6 +111,10 @@ public class TeamService {
             }
         }
 
+        String authority = waitingMember.getTeam().getId() + "_MEMBER";
+
+        user.setTeamAuthority(authority);
+
     }
 
     public TeamsResponse getTeams(Authentication authentication) {

--- a/src/main/java/com/kanvan/user/domain/User.java
+++ b/src/main/java/com/kanvan/user/domain/User.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -29,6 +30,8 @@ public class User implements UserDetails {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    private List<String> teamAuthority = new ArrayList<>();
+
     @Builder
     public User(String account, String password, String username, Role role) {
         this.account = account;
@@ -37,9 +40,20 @@ public class User implements UserDetails {
         this.role = role;
     }
 
+    public void setTeamAuthority(String authority) {
+        teamAuthority.add(authority);
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority(role.name()));
+
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(role.name()));
+
+        for (String authority : teamAuthority) {
+            authorities.add(new SimpleGrantedAuthority(authority));
+        }
+        return authorities;
     }
 
     @Override


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

- 기존 
   - 권한 설정을 하지않고, 계속 멤버를 조회해서 Role 확인
- 변경 
   - 팀장 : 팀 생성시 teamId_LEADER를 user 권한에 추가
   - 멤버 : 팀 초대 수락시 teamId_MEMBER를 user 권한에 추가

이렇게 변경하여 api 호출 시 불필요한 조회를 줄임.

## 📋 변경 사항

- [x] 새로운 기능 추가

## 📸 스크린샷

(선택 사항: 변경된 내용을 시각적으로 보여주기 위해 스크린샷을 첨부하세요.)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#18 

## 🙌 리뷰 및 피드백

(리뷰어들께 질문하거나 특정 리뷰를 요청하는 내용을 작성하세요.)
