### PR TITLE
refactor: 티켓 기능 리팩토링

### DIFF
--- a/src/main/java/com/kanvan/column/repository/ColumnRepository.java
+++ b/src/main/java/com/kanvan/column/repository/ColumnRepository.java
@@ -17,10 +17,10 @@ public interface ColumnRepository extends JpaRepository<Columns, Long> {
 
     List<Columns> findByColumnOrderGreaterThan(int columnOrder);
 
-    Optional<Columns> findColumnsByIdAndTeamId(Long columnId, Long teamId);
-
     Optional<Columns> findByColumnOrderAndTeamId(int columnOrder, Long teamId);
 
     Optional<Columns> findByTeamAndColumnOrder(Team team, int columnOrder);
+
+    Optional<Columns> findByTeamIdAndColumnOrder(Long teamId, int columnOrder);
 
 }

--- a/src/main/java/com/kanvan/column/repository/ColumnRepository.java
+++ b/src/main/java/com/kanvan/column/repository/ColumnRepository.java
@@ -19,7 +19,6 @@ public interface ColumnRepository extends JpaRepository<Columns, Long> {
 
     Optional<Columns> findByColumnOrderAndTeamId(int columnOrder, Long teamId);
 
-    Optional<Columns> findByTeamAndColumnOrder(Team team, int columnOrder);
 
     Optional<Columns> findByTeamIdAndColumnOrder(Long teamId, int columnOrder);
 

--- a/src/main/java/com/kanvan/column/repository/ColumnRepository.java
+++ b/src/main/java/com/kanvan/column/repository/ColumnRepository.java
@@ -19,7 +19,7 @@ public interface ColumnRepository extends JpaRepository<Columns, Long> {
 
     Optional<Columns> findColumnsByIdAndTeamId(Long columnId, Long teamId);
 
-    Optional<Columns> findByColumnOrderAndTeamId(Long columnIdm, Long teamId);
+    Optional<Columns> findByColumnOrderAndTeamId(int columnOrder, Long teamId);
 
     Optional<Columns> findByTeamAndColumnOrder(Team team, int columnOrder);
 

--- a/src/main/java/com/kanvan/column/repository/ColumnRepository.java
+++ b/src/main/java/com/kanvan/column/repository/ColumnRepository.java
@@ -19,6 +19,8 @@ public interface ColumnRepository extends JpaRepository<Columns, Long> {
 
     Optional<Columns> findColumnsByIdAndTeamId(Long columnId, Long teamId);
 
+    Optional<Columns> findByColumnOrderAndTeamId(Long columnIdm, Long teamId);
+
     Optional<Columns> findByTeamAndColumnOrder(Team team, int columnOrder);
 
 }

--- a/src/main/java/com/kanvan/ticket/controller/TicketController.java
+++ b/src/main/java/com/kanvan/ticket/controller/TicketController.java
@@ -31,13 +31,13 @@ public class TicketController {
     }
 
     @PatchMapping("/teams/{teamId}/columns/{columnId}/tickets/{ticketId}")
+    @PreAuthorize("hasAnyAuthority(#teamId + '_LEADER', #teamId + '_MEMBER')")
     public ResponseEntity<?> updateFields(@PathVariable(name = "teamId") Long teamId,
-                                    @PathVariable(name = "columnId") Long columnId,
-                                    @PathVariable(name = "ticketId") Long ticketId,
-                                    @Valid @RequestBody TicketUpdateRequest request,
-                                    Authentication authentication) {
+                                    @PathVariable(name = "columnId") int columnOrder,
+                                    @PathVariable(name = "ticketId") int ticketOrder,
+                                    @Valid @RequestBody TicketUpdateRequest request) {
 
-        ticketService.update(teamId, columnId, ticketId, request, authentication);
+        ticketService.update(teamId, columnOrder, ticketOrder, request);
 
         return ResponseEntity.status(HttpStatus.OK).body(null);
     }

--- a/src/main/java/com/kanvan/ticket/controller/TicketController.java
+++ b/src/main/java/com/kanvan/ticket/controller/TicketController.java
@@ -42,14 +42,14 @@ public class TicketController {
         return ResponseEntity.status(HttpStatus.OK).body(null);
     }
 
-    @PatchMapping("/{teamName}/columns/{columnId}/tickets/{ticketId}/order")
-    public ResponseEntity<?> updateOrders(@PathVariable(name = "teamName") String teamName,
-                                          @PathVariable(name = "columnId") int columnId,
-                                          @PathVariable(name = "ticketId") int ticketId,
-                                          @Valid @RequestBody TicketOrderUpdateRequest request,
-                                          Authentication authentication) {
+    @PatchMapping("/teams/{teamId}/columns/{columnId}/tickets/{ticketId}/order")
+    @PreAuthorize("hasAnyAuthority(#teamId + '_LEADER', #teamId + '_MEMBER')")
+    public ResponseEntity<?> updateOrders(@PathVariable(name = "teamId") Long teamId,
+                                          @PathVariable(name = "columnId") int columnOrder,
+                                          @PathVariable(name = "ticketId") int ticketOrder,
+                                          @Valid @RequestBody TicketOrderUpdateRequest request) {
 
-        ticketService.updateOrders(teamName, columnId, ticketId, request, authentication);
+        ticketService.updateOrders(teamId, columnOrder, ticketOrder, request);
 
         return ResponseEntity.status(HttpStatus.OK).body(null);
     }

--- a/src/main/java/com/kanvan/ticket/controller/TicketController.java
+++ b/src/main/java/com/kanvan/ticket/controller/TicketController.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,12 +20,12 @@ public class TicketController {
     private final TicketService ticketService;
 
     @PostMapping("/teams/{teamId}/columns/{columnId}/tickets")
+    @PreAuthorize("hasAnyAuthority(#teamId + '_LEADER', #teamId + '_MEMBER')")
     public ResponseEntity<?> create(@PathVariable(name = "teamId") Long teamId,
                                     @PathVariable(name = "columnId") Long columnId,
-                                    @Valid @RequestBody TicketCreateRequest request,
-                                    Authentication authentication) {
+                                    @Valid @RequestBody TicketCreateRequest request) {
 
-        ticketService.create(teamId, columnId, request, authentication);
+        ticketService.create(teamId, columnId, request);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(null);
     }

--- a/src/main/java/com/kanvan/ticket/controller/TicketController.java
+++ b/src/main/java/com/kanvan/ticket/controller/TicketController.java
@@ -54,12 +54,12 @@ public class TicketController {
         return ResponseEntity.status(HttpStatus.OK).body(null);
     }
 
-    @DeleteMapping("/{teamName}/columns/{columnId}/tickets/{ticketId}")
-    public ResponseEntity<?> delete(@PathVariable(name = "teamName") String teamName,
-                                    @PathVariable(name = "columnId") int columnId,
-                                    @PathVariable(name = "ticketId") int ticketId,
-                                    Authentication authentication) {
-        ticketService.delete(teamName, columnId, ticketId, authentication);
+    @DeleteMapping("/teams/{teamId}/columns/{columnId}/tickets/{ticketId}")
+    @PreAuthorize("hasAnyAuthority(#teamId + '_LEADER', #teamId + '_MEMBER')")
+    public ResponseEntity<?> delete(@PathVariable(name = "teamId") Long teamId,
+                                    @PathVariable(name = "columnId") int columnOrder,
+                                    @PathVariable(name = "ticketId") int ticketOrder) {
+        ticketService.delete(teamId, columnOrder, ticketOrder);
 
         return ResponseEntity.status(HttpStatus.OK).body(null);
     }

--- a/src/main/java/com/kanvan/ticket/controller/TicketController.java
+++ b/src/main/java/com/kanvan/ticket/controller/TicketController.java
@@ -22,10 +22,10 @@ public class TicketController {
     @PostMapping("/teams/{teamId}/columns/{columnId}/tickets")
     @PreAuthorize("hasAnyAuthority(#teamId + '_LEADER', #teamId + '_MEMBER')")
     public ResponseEntity<?> create(@PathVariable(name = "teamId") Long teamId,
-                                    @PathVariable(name = "columnId") Long columnId,
+                                    @PathVariable(name = "columnId") int columnOrder,
                                     @Valid @RequestBody TicketCreateRequest request) {
 
-        ticketService.create(teamId, columnId, request);
+        ticketService.create(teamId, columnOrder, request);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(null);
     }

--- a/src/main/java/com/kanvan/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/kanvan/ticket/repository/TicketRepository.java
@@ -11,8 +11,6 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
     List<Ticket> findByColumn(Columns column);
 
-    Optional<Ticket> findByTicketOrder(int ticketOrder);
-
     List<Ticket> findByTicketOrderBetween(int min, int max);
 
     List<Ticket> findByColumnAndTicketOrderGreaterThan(Columns column, int ticketOrder);

--- a/src/main/java/com/kanvan/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/kanvan/ticket/repository/TicketRepository.java
@@ -16,4 +16,6 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
     List<Ticket> findByTicketOrderBetween(int min, int max);
 
     List<Ticket> findByColumnAndTicketOrderGreaterThan(Columns column, int ticketOrder);
+
+    Optional<Ticket> findByTicketOrderAndColumnId(int ticketOrder, Long columnId);
 }

--- a/src/main/java/com/kanvan/ticket/service/TicketService.java
+++ b/src/main/java/com/kanvan/ticket/service/TicketService.java
@@ -103,7 +103,6 @@ public class TicketService {
             List<Ticket> tickets = ticketRepository.findByColumnAndTicketOrderGreaterThan(column, ticketId);
 
             tickets.forEach(tk -> {
-                System.out.println(tk.getTitle());
                 tk.updateTicketOrder(tk.getTicketOrder() - 1);
             });
             List<Ticket> changedColumnTickets = ticketRepository.findByColumnAndTicketOrderGreaterThan(changedColumn, request.getTicketOrder() - 1);

--- a/src/main/java/com/kanvan/ticket/service/TicketService.java
+++ b/src/main/java/com/kanvan/ticket/service/TicketService.java
@@ -35,29 +35,19 @@ public class TicketService {
     private final TeamRepository teamRepository;
 
     @Transactional
-    public void create(Long teamId, Long columnId, TicketCreateRequest request,
-                       Authentication authentication) {
-
-        //todo 조회 줄이기 -> if i can
+    public void create(Long teamId, Long columnId, TicketCreateRequest request) {
 
         //작업자
         User manager = userRepository.findByAccount(request.getMemberAccount()).orElseThrow(
                 () -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
+        //멤버 검증
+        Member verifiedMember = memberRepository.findByMemberAndTeamId(manager, teamId).orElseThrow(
+                () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
         //컬럼
         Columns column = columnRepository.findColumnsByIdAndTeamId(columnId, teamId).orElseThrow(
                 () -> new CustomException(ErrorCode.COLUMN_NOT_FOUND));
-
-        //===== 여기부터는 권한때문인데 고민해봐야함 =====//
-        User user = userRepository.findByAccount(authentication.getName()).orElseThrow(
-                () -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        Member member = memberRepository.findByMemberAndTeamId(user, teamId).orElseThrow(
-                () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-
-        Member worker = memberRepository.findByMemberAndTeamId(manager, teamId).orElseThrow(
-                () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-        //===== 여기까지는 권한때문인데 고민해봐야함 =====//
 
         int order =  ticketRepository.findByColumn(column).size();
 

--- a/src/main/java/com/kanvan/ticket/service/TicketService.java
+++ b/src/main/java/com/kanvan/ticket/service/TicketService.java
@@ -46,7 +46,7 @@ public class TicketService {
                 () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         //컬럼
-        Columns column = columnRepository.findColumnsByIdAndTeamId(columnId, teamId).orElseThrow(
+        Columns column = columnRepository.findByColumnOrderAndTeamId(columnId, teamId).orElseThrow(
                 () -> new CustomException(ErrorCode.COLUMN_NOT_FOUND));
 
         int order =  ticketRepository.findByColumn(column).size();

--- a/src/main/java/com/kanvan/ticket/service/TicketService.java
+++ b/src/main/java/com/kanvan/ticket/service/TicketService.java
@@ -131,23 +131,13 @@ public class TicketService {
     }
 
     @Transactional
-    public void delete(String teamName, int columnId, int ticketId, Authentication authentication) {
-        Ticket ticket = ticketRepository.findByTicketOrder(ticketId).orElseThrow(
-                () -> new CustomException(ErrorCode.TICKET_NOT_FOUND));
+    public void delete(Long teamId, int columnId, int ticketId) {
 
-        Team team = teamRepository.findByTeamName(teamName).orElseThrow(
-                () -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
-
-        Columns column = columnRepository.findByTeamAndColumnOrder(team, columnId).orElseThrow(
+        Columns column = columnRepository.findByTeamIdAndColumnOrder(teamId, columnId).orElseThrow(
                 () -> new CustomException(ErrorCode.COLUMN_NOT_FOUND));
 
-        //===== 권한 확인 =====//
-        User user = userRepository.findByAccount(authentication.getName()).orElseThrow(
-                () -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        Member member = memberRepository.findByMemberAndTeam(user, team).orElseThrow(
-                () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-        //===== 권한 확인 =====//
+        Ticket ticket = ticketRepository.findByTicketOrderAndColumnId(ticketId, column.getId()).orElseThrow(
+                () -> new CustomException(ErrorCode.TICKET_NOT_FOUND));
 
         ticketRepository.delete(ticket);
 

--- a/src/main/java/com/kanvan/ticket/service/TicketService.java
+++ b/src/main/java/com/kanvan/ticket/service/TicketService.java
@@ -35,7 +35,7 @@ public class TicketService {
     private final TeamRepository teamRepository;
 
     @Transactional
-    public void create(Long teamId, Long columnId, TicketCreateRequest request) {
+    public void create(Long teamId, int columnId, TicketCreateRequest request) {
 
         //작업자
         User manager = userRepository.findByAccount(request.getMemberAccount()).orElseThrow(


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

- 티켓 리팩토링
   - 팀을 생성하거나 초대를 수락시 user에 해당 팀에 대한 권한 추가
   - 기존 멤버 검증을 위한 조회 삭제 -> @preauthorize를 통해 해당 팀에 권한이 있는지 확인
   - api url -> 최대한 restful하게 변경
   - 기존 조회(DB 테이블에 저장된 Id) 조회 -> 순서를 조회(몇번 팀의 몇번째 순서의 컬럼의 몇번째 순서의 티켓)


## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## 📸 스크린샷

(선택 사항: 변경된 내용을 시각적으로 보여주기 위해 스크린샷을 첨부하세요.)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#20 

## 🙌 리뷰 및 피드백

(리뷰어들께 질문하거나 특정 리뷰를 요청하는 내용을 작성하세요.)
